### PR TITLE
Fixing SimpleLazyObject Issue

### DIFF
--- a/tavern/templates/tavern/past_events.html
+++ b/tavern/templates/tavern/past_events.html
@@ -3,6 +3,8 @@
     <ul>
     {% for event in past_events %}
         <li><a href="{% url 'tavern_event_details' event.slug %}">{{ event.name }}</a></li>
+        {% empty %}
+        No Completed Events
     {% endfor %}
     </ul>
 </div>

--- a/tavern/views.py
+++ b/tavern/views.py
@@ -138,7 +138,7 @@ class EventDetail(UpcomingEventsMixin, DetailView):
         group = TavernGroup.objects.get(slug=group_name)
         event = group.event_set.get(slug=event_name)
         try:
-            attendee = Attendee.objects.get(user=self.request.user,
+            attendee = Attendee.objects.get(user=self.request.user.id,
                                             event=event)
             if attendee.rsvp_status == 'yes':
                 message = "You are attending this event."


### PR DESCRIPTION
@akshar-raaj Before the user has been logged in, we are showing the list of groups in the home page. Here after clicking the group name, it shows all the events for that group. 
Error - After clicking one of the events name, it is showing the error attached in the image below
![screenshot from 2014-10-13 17 41 27](https://cloud.githubusercontent.com/assets/7446464/4613116/00869290-52d2-11e4-89d1-0d8a031b2050.png)
This error was bcoz request.user is not the real user object. Before login authentication, it should return the instance of AnonymousUser. After login, it returns the instance of User.
For this we return the particular instance by using 'id' i.e., we are writing request.user.id instead of that.
