### PR TITLE
Added event location in template, Showing location in google maps

### DIFF
--- a/tavern/templates/tavern/event_details.html
+++ b/tavern/templates/tavern/event_details.html
@@ -9,7 +9,8 @@
 
     {% if event.starts_at %}
         <h3> Event starts on </h3>
-        {{ event.starts_at }}
+        {{ event.starts_at }} at 
+        <a href="https://www.google.co.in/maps/place/{{ event.location }}" target="_blank"> {{ event.location }} </a>
         <hr/>
     {% endif %}
 


### PR DESCRIPTION
@akshar-raaj Before we are not showing the event location in the event_detail page. Added the link of event location in the template. Clicking in the event location opens new window of showing the location in google maps
